### PR TITLE
ci: fix red cross on experimental

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
   tests:
     needs: [ pre-commit ]
     uses: ./.github/workflows/step_test.yaml
+    with:
+      mask-experimental: ${{ github.event_name == 'push' }}
 
   docs:
     name: 📘 docs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,8 @@ jobs:
   tests:
     needs: [ pre-commit ]
     uses: ./.github/workflows/step_test.yaml
+    with:
+      mask-experimental: true
 
   docs:
     name: 📘 docs

--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -2,6 +2,11 @@ name: test
 
 on:
   workflow_call:
+    inputs:
+      mask-experimental:
+        type: boolean
+        default: true
+        description: Always report experimental test as successful
 
 permissions:
   contents: read
@@ -38,3 +43,4 @@ jobs:
         uses: lukka/run-cmake@v10.3
         with:
           workflowPreset: "${{ matrix.toolchain }}-ci"
+        continue-on-error: ${{ matrix.experimental == 'true' && inputs.mask-experimental}}


### PR DESCRIPTION
Uses [`steps.*.continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)