### PR TITLE
fix: red-cross in commit status

### DIFF
--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -43,4 +43,4 @@ jobs:
         uses: lukka/run-cmake@v10.3
         with:
           workflowPreset: "${{ matrix.toolchain }}-ci"
-        continue-on-error: ${{ matrix.experimental == 'true' && inputs.mask-experimental}}
+        continue-on-error: ${{ matrix.experimental && inputs.mask-experimental}}


### PR DESCRIPTION
#6 did not mask the results properly, this one should do the trick.

GitHub is not consistent when a variable is converted to a string and when it is a json-native object. In this case, the matrix variable is kept as json-native bool