### PR TITLE
ci: Update sonarcloud

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,13 @@ jobs:
     with:
       mask-experimental: true
 
+  # Normally this is unnecessary, but for sonarcloud, this tags the new version
+  static-analysis:
+    needs: [ pre-commit ]
+    uses: ./.github/workflows/step_static-analysis.yaml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   docs:
     name: 📘 docs
     needs: [ pre-commit ]
@@ -25,7 +32,7 @@ jobs:
 
   tests-pass:
     name: ✅ Pass
-    needs: [ pre-commit, tests, docs ]
+    needs: [ pre-commit, tests, static-analysis, docs ]
     runs-on: ubuntu-latest
     steps:
       - name: Check all CI jobs

--- a/.github/workflows/step_static-analysis.yaml
+++ b/.github/workflows/step_static-analysis.yaml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: WyriHaximus/github-action-get-previous-tag@v1
+        id: git-tag
+        with:
+         prefix: v
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v2
       - uses: lukka/get-cmake@latest
@@ -29,3 +35,4 @@ jobs:
           sonar-scanner
           --define sonar.cfamily.compile-commands="$(echo cmake-build-*)/compile_commands.json"
           --define sonar.coverageReportPaths=coverage.xml
+          --define sonar.projectVersion=${{ steps.git-tag.outputs.tag }}

--- a/.github/workflows/step_static-analysis.yaml
+++ b/.github/workflows/step_static-analysis.yaml
@@ -29,10 +29,9 @@ jobs:
         run: pipx run gcovr --sonarqube > coverage.xml
       - name: Run sonar-scanner
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >
           sonar-scanner
-          --define sonar.cfamily.compile-commands="$(echo cmake-build-*)/compile_commands.json"
+          --define sonar.cfamily.compile-commands=$(echo cmake-build-*)/compile_commands.json
           --define sonar.coverageReportPaths=coverage.xml
           --define sonar.projectVersion=${{ steps.git-tag.outputs.tag }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=LecrisUT_CMake-Template
 sonar.organization=lecris
 
-sonar.projectName="CMake Template"
-sonar.coverage.exclusions=test/**, docs/**
+sonar.projectName=CMake Template
+sonar.sources=src
+sonar.tests=test


### PR DESCRIPTION
- ~~Simplify the workflow. Not using the wrapper, so might as well just call the scanner~~. Cannot use `SonarSource/sonarcloud-github-action` directly because the container does not have access to the runner's work directory
- Add the version to `sonar.projectVersion`. This is not ideal, but trying to get feedback from upstream: https://community.sonarsource.com/t/sonar-projectversion-from-git-tag/106393